### PR TITLE
Update README.md `->nullable()` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Schema::table('posts', function (Blueprint $table) {
 });
 ```
 
-**Review the migration before running it.** The right shape depends on how you configured the attribute and the state of your existing data. For example, on an existing table you typically want to use the `->nullable()`, etc.
+**Review the migration before running it.** The right shape depends on how you configured the attribute and the state of your existing data. For example, on a table with existing rows you typically want to use the `->nullable()`, etc.
 
 Once the migration is in shape, run:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Schema::table('posts', function (Blueprint $table) {
 });
 ```
 
-**Review the migration before running it.** The right shape depends on how you configured the attribute and the state of your existing data. For example, on a new table you typically want to use the `->nullable()`, etc.
+**Review the migration before running it.** The right shape depends on how you configured the attribute and the state of your existing data. For example, on an existing table you typically want to use the `->nullable()`, etc.
 
 Once the migration is in shape, run:
 


### PR DESCRIPTION
If understand right, an existing table will need nullable since existing data will not have a slug and will need this set via a migration/command/etc. Whereas a new table will never have `null` slugs, so it does not need this column to be nullable?